### PR TITLE
Remove threading code and add internal clock to the simulation

### DIFF
--- a/src/main/java/thewaypointers/trafficsimulator/TrafficSimulatorManager.java
+++ b/src/main/java/thewaypointers/trafficsimulator/TrafficSimulatorManager.java
@@ -8,24 +8,19 @@ import thewaypointers.trafficsimulator.simulation.Simulation;
 
 public class TrafficSimulatorManager {
 
-    final static long TIME_STEP = 500;
+    final static long TIME_STEP = 100;
+    final static long SIMULATION_TIME_STEP = 300;
     static WorldStateDTO worldState;
 
     public static void main(String[] args) {
 
-        SimulatorRunnable simulatorRunnable = new SimulatorRunnable();
-        Thread t = new Thread(simulatorRunnable);
-        t.start();
-
-        //temp fix
-        waitForThread();
-        worldState = simulatorRunnable.getWorldState();
+        Simulation simulation = new Simulation();
         MainFrame mainFrame = new MainFrame(worldState);
         while(true){
             try{
                 Thread.sleep(TIME_STEP);
-                worldState = simulatorRunnable.getWorldState();
-                mainFrame.mapContainerPanel.mapPanel.NewStateReceived(worldState);
+                worldState = simulation.getNextSimulationStep(SIMULATION_TIME_STEP);
+                MainFrame.mapContainerPanel.mapPanel.NewStateReceived(worldState);
                 output();
             }
             catch(InterruptedException ex){
@@ -50,20 +45,6 @@ public class TrafficSimulatorManager {
                 loc.getRoad().getFrom().getLabel(),
                 loc.getRoad().getTo().getLabel());
         System.out.println();
-    }
-
-    public static class SimulatorRunnable implements Runnable {
-
-        Simulation sim;
-
-        public void run() {
-            sim = new Simulation();
-            sim.runSimulation();
-        }
-
-        public WorldStateDTO getWorldState(){
-            return sim.getWorldState();
-        }
     }
 
 }

--- a/src/main/java/thewaypointers/trafficsimulator/simulation/Simulation.java
+++ b/src/main/java/thewaypointers/trafficsimulator/simulation/Simulation.java
@@ -27,20 +27,20 @@ public class Simulation implements ISimulationInputListener {
 
     GraphFactory graphFactory;
 
-    final long SIMULATION_TIME_STEP = 500;
     final int MAX_VEHICLE_NUMBER = 1;
     final int TRAFFIC_LIGHT_STEPS = 10;
-    final long SIMULATION_TIME_MULTIPLIER = 2;
     int currentVehicleNumber = 0;
     int trafficLightCounter = 0;
 
+    /**
+     * The maximum internal clock time interval at which computation occurs.
+     */
+    final long RESOLUTION = 300;
 
-    //TODO: use this constructor in the simulation manager
-    public Simulation(IStateChangeListener stateChangeListener) {
-        this.stateChangeListener = stateChangeListener;
-        initiateSimulation();
-    }
-
+    /**
+     * The internal time clock.
+     */
+    long clock = 0;
 
     public Simulation(){
         initiateSimulation();
@@ -53,40 +53,30 @@ public class Simulation implements ISimulationInputListener {
         createVehicles();
     }
 
-    //timesteps
-    public void runSimulation(){
-        run = true;
-        while(run){
-
-            NextSimulationStep();
-
-            try{
-                Thread.sleep(SIMULATION_TIME_STEP);
-            }catch(Exception ex){
-                System.out.println(ex.getMessage());
-            }
-
-        }
-    }
-
     public void SimulationParameterChanged(String parameterName, String value) {
         // set new value for the parameter in the simulation
     }
 
-    public void NextSimulationStep(){
+    public WorldStateDTO getNextSimulationStep(long timeStep){
 
-            try{
-                moveVehicles(SIMULATION_TIME_STEP * SIMULATION_TIME_MULTIPLIER);
-                checkForLeavingVehicles();
-            }
-            catch (Exception ex){
-                System.out.println(ex.getMessage());
-            }
+        long timeLeft = timeStep;
+        while(timeLeft > RESOLUTION) {
+            timeLeft -= RESOLUTION;
+            computeNextSimulationStep(RESOLUTION);
+        }
+        computeNextSimulationStep(timeLeft);
+        return getWorldState();
+    }
 
+    private void computeNextSimulationStep(long timeStep){
+        moveVehicles(timeStep);
+        checkForLeavingVehicles();
 
         //temp
         changeWorldState();
         changeTrafficLightState();
+
+        clock += timeStep;
     }
 
     private synchronized void changeWorldState() {


### PR DESCRIPTION
My solution to making the simulation test-friendly and making it independent of real-world time.