### PR TITLE
Done junctionlocation-21

### DIFF
--- a/src/main/java/thewaypointers/trafficsimulator/FirstVersionStarter.java
+++ b/src/main/java/thewaypointers/trafficsimulator/FirstVersionStarter.java
@@ -1,6 +1,7 @@
 package thewaypointers.trafficsimulator;
 
 import thewaypointers.trafficsimulator.common.WorldStateDTO;
+import thewaypointers.trafficsimulator.common.helpers.SimpleWorldState;
 import thewaypointers.trafficsimulator.common.helpers.SimpleWorldStateProvider;
 import thewaypointers.trafficsimulator.gui.MainFrame;
 
@@ -11,11 +12,12 @@ public class FirstVersionStarter {
 
     public static void main(String[] args){
 
-        SimpleWorldStateProvider simulation = new SimpleWorldStateProvider();   // this will be simulation
+        SimpleWorldStateProvider simulation = new SimpleWorldStateProvider(SimpleWorldState.ROAD_NETWORK);   // this will be simulation
         //IStateChangeListener gui = new SimpleStateChangeListener();   // put your GUI here
         MainFrame mainFrame=new MainFrame(simulation.getNextState(0));
 
 
+        //noinspection InfiniteLoopStatement
         while(true){
             WorldStateDTO newWorldState = simulation.getNextState(VEHICLE_MOVEMENT_SPEED);
             //gui.NewStateReceived(newWorldState);   // in this method the GUI draws the new world state

--- a/src/main/java/thewaypointers/trafficsimulator/FirstVersionStarter.java
+++ b/src/main/java/thewaypointers/trafficsimulator/FirstVersionStarter.java
@@ -20,7 +20,6 @@ public class FirstVersionStarter {
         //noinspection InfiniteLoopStatement
         while(true){
             WorldStateDTO newWorldState = simulation.getNextState(VEHICLE_MOVEMENT_SPEED);
-            //gui.NewStateReceived(newWorldState);   // in this method the GUI draws the new world state
             MainFrame.mapContainerPanel.mapPanel.NewStateReceived(newWorldState);
             try {
                 Thread.sleep((long)(1f/STATES_PER_SECOND * 1000));

--- a/src/main/java/thewaypointers/trafficsimulator/JunctionLocationTestStarter.java
+++ b/src/main/java/thewaypointers/trafficsimulator/JunctionLocationTestStarter.java
@@ -1,0 +1,39 @@
+package thewaypointers.trafficsimulator;
+
+import thewaypointers.trafficsimulator.common.JunctionLocationDTO;
+import thewaypointers.trafficsimulator.common.WorldStateDTO;
+import thewaypointers.trafficsimulator.common.helpers.SimpleWorldState;
+import thewaypointers.trafficsimulator.common.helpers.SimpleWorldStateProvider;
+import thewaypointers.trafficsimulator.gui.MainFrame;
+import thewaypointers.trafficsimulator.utils.FloatPoint;
+
+public class JunctionLocationTestStarter {
+
+    public static final float VEHICLE_MOVEMENT_SPEED = 2;
+    public static final float STATES_PER_SECOND = 1;
+
+    public static void main(String[] args){
+
+        SimpleWorldStateProvider simulation = new SimpleWorldStateProvider(SimpleWorldState.JUNCTION_LOCATION_TEST);
+        MainFrame mainFrame=new MainFrame(simulation.getNextState(0));
+
+        //noinspection InfiniteLoopStatement
+        while(true){
+            WorldStateDTO newWorldState = simulation.getNextState(VEHICLE_MOVEMENT_SPEED);
+            JunctionLocationDTO loc = (JunctionLocationDTO) newWorldState
+                    .getVehicleList().getVehicle("V1").getLocation();
+            FloatPoint coords = loc.getJunctionCoordinates();
+            System.out.println(String.format(
+                    "Vehicle coordinates: (%f, %f), angle: %f",
+                    coords.getX(),
+                    coords.getY(),
+                    loc.getAngle()));
+            MainFrame.mapContainerPanel.mapPanel.NewStateReceived(newWorldState);
+            try {
+                Thread.sleep((long)(1f/STATES_PER_SECOND * 1000));
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/thewaypointers/trafficsimulator/TrafficSimulatorManager.java
+++ b/src/main/java/thewaypointers/trafficsimulator/TrafficSimulatorManager.java
@@ -1,7 +1,5 @@
 package thewaypointers.trafficsimulator;
 
-import thewaypointers.trafficsimulator.common.LocationDTO;
-import thewaypointers.trafficsimulator.common.VehicleDTO;
 import thewaypointers.trafficsimulator.common.WorldStateDTO;
 import thewaypointers.trafficsimulator.gui.MainFrame;
 import thewaypointers.trafficsimulator.simulation.Simulation;

--- a/src/main/java/thewaypointers/trafficsimulator/common/Direction.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/Direction.java
@@ -38,4 +38,22 @@ public enum Direction {
     public Direction opposite(){
         return oppositeMap.get(this);
     }
+
+    public Direction toLeft(){
+        switch(this){
+            case Down:
+                return Left;
+            case Left:
+                return Up;
+            case Up:
+                return Right;
+            case Right:
+                return Down;
+        }
+        throw new AssertionError("Unexpected enum value");
+    }
+
+    public Direction toRight(){
+        return toLeft().opposite();
+    }
 }

--- a/src/main/java/thewaypointers/trafficsimulator/common/ILocation.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/ILocation.java
@@ -1,0 +1,5 @@
+package thewaypointers.trafficsimulator.common;
+
+public interface ILocation {
+    ILocation copy();
+}

--- a/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
@@ -108,10 +108,10 @@ public class JunctionLocationDTO implements ILocation {
                 rotated = coords;
                 break;
             case Right:
-                rotated = coords.rotate90(center, Rotation.Counterclockwise);
+                rotated = coords.rotate90(center, Rotation.Clockwise);
                 break;
             case Left:
-                rotated = coords.rotate90(center, Rotation.Clockwise);
+                rotated = coords.rotate90(center, Rotation.Counterclockwise);
                 break;
             case Up:
                 rotated = coords.mirror(center);

--- a/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
@@ -4,20 +4,20 @@ import thewaypointers.trafficsimulator.utils.FloatPoint;
 import thewaypointers.trafficsimulator.utils.Rotation;
 
 public class JunctionLocationDTO implements ILocation {
-    private JunctionDTO junction;
+    private String junctionLabel;
     private Direction origin;
     private Direction target;
     private float percentageTravelled;
 
-    public JunctionLocationDTO(JunctionDTO junction, Direction origin, Direction target, float percentageTravelled) {
-        this.junction = junction;
+    public JunctionLocationDTO(String junctionLabel, Direction origin, Direction target, float percentageTravelled) {
+        this.junctionLabel = junctionLabel;
         this.origin = origin;
         this.target = target;
         this.percentageTravelled = percentageTravelled;
     }
 
-    public JunctionDTO getJunction() {
-        return junction;
+    public String getJunctionLabel() {
+        return junctionLabel;
     }
 
     public Direction getOrigin() {
@@ -33,12 +33,25 @@ public class JunctionLocationDTO implements ILocation {
     }
 
     public JunctionLocationDTO(JunctionLocationDTO other){
-        this(other.getJunction(), other.getOrigin(), other.getTarget(), other.getPercentageTravelled());
+        this(other.getJunctionLabel(), other.getOrigin(), other.getTarget(), other.getPercentageTravelled());
     }
 
     @Override
     public ILocation copy() {
         return new JunctionLocationDTO(this);
+    }
+
+    public boolean equals(JunctionLocationDTO other){
+        return  getJunctionLabel().equals(other.getJunctionLabel()) &&
+                getTarget().equals(other.getTarget()) &&
+                getOrigin().equals(other.getOrigin()) &&
+                getPercentageTravelled() == other.getPercentageTravelled();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o.getClass() == JunctionLocationDTO.class &&
+                equals((JunctionLocationDTO)o);
     }
 
     // default origin - Down

--- a/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
@@ -1,8 +1,113 @@
 package thewaypointers.trafficsimulator.common;
 
+import thewaypointers.trafficsimulator.utils.FloatPoint;
+import thewaypointers.trafficsimulator.utils.Rotation;
+
 public class JunctionLocationDTO implements ILocation {
+    private JunctionDTO junction;
+    private Direction origin;
+    private Direction target;
+    private float percentageTravelled;
+
+    public JunctionLocationDTO(JunctionDTO junction, Direction origin, Direction target, float percentageTravelled) {
+        this.junction = junction;
+        this.origin = origin;
+        this.target = target;
+        this.percentageTravelled = percentageTravelled;
+    }
+
+    public JunctionDTO getJunction() {
+        return junction;
+    }
+
+    public Direction getOrigin() {
+        return origin;
+    }
+
+    public Direction getTarget() {
+        return target;
+    }
+
+    public float getPercentageTravelled() {
+        return percentageTravelled;
+    }
+
+    public JunctionLocationDTO(JunctionLocationDTO other){
+        this(other.getJunction(), other.getOrigin(), other.getTarget(), other.getPercentageTravelled());
+    }
+
     @Override
     public ILocation copy() {
-        return null;
+        return new JunctionLocationDTO(this);
     }
+
+    // default origin - Down
+    private FloatPoint getLeftTurnRouteCoordinates(float progress){
+        float x,y;
+        if (progress <= 1/3f){
+            x = 0.75f;
+            y = 1 - 0.5f*(progress*3);
+        }else if(progress >= 1/3f && progress <= 2/3f){
+            double radians = Math.toRadians((progress-1/3f)*3*90);
+            x = (float)(0.75-0.25*Math.sin(radians));
+            y = (float)(0.5-0.25*Math.sin(radians));
+        }else{
+            x = 0.5f - 0.5f*(progress-2/3f)*3;
+            y = 0.25f;
+        }
+        return new FloatPoint(x,y);
+    }
+
+    // default origin - Down
+    private FloatPoint getRightTurnRouteCoordinates(float progress){
+        double radians = Math.toRadians(progress*90);
+        float x = (float)(0.75f + 0.25*Math.sin(radians));
+        float y = (float)(1 - 0.25*Math.sin(radians));
+        return new FloatPoint(x,y);
+    }
+
+    // default origin - Down
+    private FloatPoint getStraightRouteCoordinates(float progress){
+        float x = 0.75f;
+        float y = 1 - progress;
+        return new FloatPoint(x,y);
+    }
+
+    public FloatPoint getJunctionCoordinates(){
+
+        // get correct curve
+        FloatPoint coords;
+        if(getTarget().equals(getOrigin().toLeft())){
+            coords = getLeftTurnRouteCoordinates(getPercentageTravelled());
+        }else if(getTarget().equals(getOrigin().toRight())){
+            coords = getRightTurnRouteCoordinates(getPercentageTravelled());
+        }else if(getTarget().equals(getOrigin().opposite())){
+            coords = getStraightRouteCoordinates(getPercentageTravelled());
+        }else{
+            throw new AssertionError(String.format(
+                    "Invalid target %s for origin %s", getTarget(), getOrigin()));
+        }
+
+        // rotate the coordinates
+        FloatPoint rotated, center = new FloatPoint(0.5f,0.5f);
+        switch(getOrigin()){
+            case Down:
+                rotated = coords;
+                break;
+            case Right:
+                rotated = coords.rotate90(center, Rotation.Counterclockwise);
+                break;
+            case Left:
+                rotated = coords.rotate90(center, Rotation.Clockwise);
+                break;
+            case Up:
+                rotated = coords.mirror(center);
+                break;
+            default:
+                throw new AssertionError(String.format(
+                        "Unexpected enum value: %s", getOrigin()));
+        }
+        return rotated;
+    }
+
 }

--- a/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/JunctionLocationDTO.java
@@ -1,0 +1,8 @@
+package thewaypointers.trafficsimulator.common;
+
+public class JunctionLocationDTO implements ILocation {
+    @Override
+    public ILocation copy() {
+        return null;
+    }
+}

--- a/src/main/java/thewaypointers/trafficsimulator/common/JunctionMoveResult.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/JunctionMoveResult.java
@@ -1,0 +1,19 @@
+package thewaypointers.trafficsimulator.common;
+
+public class JunctionMoveResult {
+    JunctionLocationDTO newLocation;
+    float remainder;
+
+    public JunctionMoveResult(JunctionLocationDTO newLocation, float remainder) {
+        this.newLocation = newLocation;
+        this.remainder = remainder;
+    }
+
+    public JunctionLocationDTO getNewLocation() {
+        return newLocation;
+    }
+
+    public float getRemainder() {
+        return remainder;
+    }
+}

--- a/src/main/java/thewaypointers/trafficsimulator/common/RoadLocationDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/RoadLocationDTO.java
@@ -1,6 +1,6 @@
 package thewaypointers.trafficsimulator.common;
 
-public class LocationDTO {
+public class RoadLocationDTO implements ILocation{
     private RoadDTO road;
     private float distanceTravelled;
     private NodeDTO origin;
@@ -22,14 +22,19 @@ public class LocationDTO {
         return lane;
     }
 
-    public LocationDTO(RoadDTO road, NodeDTO origin, float distanceTravelled, Lane lane) {
+    public RoadLocationDTO(RoadDTO road, NodeDTO origin, float distanceTravelled, Lane lane) {
         this.road = road;
         this.distanceTravelled = distanceTravelled;
         this.origin = origin;
         this.lane = lane;
     }
 
-    public LocationDTO(LocationDTO other){
+    public RoadLocationDTO(RoadLocationDTO other){
         this(other.road, other.origin, other.distanceTravelled, other.lane);
+    }
+
+    @Override
+    public ILocation copy() {
+        return new RoadLocationDTO(this);
     }
 }

--- a/src/main/java/thewaypointers/trafficsimulator/common/VehicleDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/VehicleDTO.java
@@ -44,7 +44,7 @@ public class VehicleDTO {
         return location;
     }
 
-    void setLocation(RoadLocationDTO location) {
+    void setLocation(ILocation location) {
         this.location = location;
     }
 

--- a/src/main/java/thewaypointers/trafficsimulator/common/VehicleDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/VehicleDTO.java
@@ -3,15 +3,15 @@ package thewaypointers.trafficsimulator.common;
 public class VehicleDTO {
     private String label;
     private float speed;
-    private LocationDTO location;
+    private ILocation location;
     private VehicleType type;
 
-    public VehicleDTO(String label, float speed, LocationDTO location, VehicleType type) {
+    public VehicleDTO(String label, float speed, ILocation location, VehicleType type) {
         this(label, location, type);
         this.speed = speed;
     }
 
-    public VehicleDTO(String label, LocationDTO location, VehicleType type){
+    public VehicleDTO(String label, ILocation location, VehicleType type){
         this.label = label;
         this.location = location;
         this.type = type;
@@ -19,7 +19,7 @@ public class VehicleDTO {
 
     public VehicleDTO(VehicleDTO other){
         this.label = other.getLabel();
-        this.location = new LocationDTO(other.getLocation());
+        this.location = other.getLocation().copy();
         this.speed = other.getSpeed();
         this.type = other.getType();
     }
@@ -40,11 +40,11 @@ public class VehicleDTO {
         this.speed = speed;
     }
 
-    public LocationDTO getLocation() {
+    public ILocation getLocation() {
         return location;
     }
 
-    void setLocation(LocationDTO location) {
+    void setLocation(RoadLocationDTO location) {
         this.location = location;
     }
 

--- a/src/main/java/thewaypointers/trafficsimulator/common/VehicleListDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/VehicleListDTO.java
@@ -17,11 +17,11 @@ public class VehicleListDTO {
         vehicles.put(vehicle.getLabel(), new VehicleDTO(vehicle));
     }
 
-    public void addVehicle(String label, RoadLocationDTO location, VehicleType type){
+    public void addVehicle(String label, ILocation location, VehicleType type){
         vehicles.put(label, new VehicleDTO(label, location, type));
     }
 
-    public void addVehicle(String label, RoadLocationDTO location, VehicleType type, float speed){
+    public void addVehicle(String label, ILocation location, VehicleType type, float speed){
         vehicles.put(label, new VehicleDTO(label, speed, location, type));
     }
 
@@ -33,8 +33,8 @@ public class VehicleListDTO {
         vehicles.get(label).setSpeed(newSpeed);
     }
 
-    public void setVehicleLocation(String label, RoadLocationDTO newLocation){
-        vehicles.get(label).setLocation(new RoadLocationDTO(newLocation));
+    public void setVehicleLocation(String label, ILocation newLocation){
+        vehicles.get(label).setLocation(newLocation);
     }
 
     public List<VehicleDTO> getAll(){

--- a/src/main/java/thewaypointers/trafficsimulator/common/VehicleListDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/VehicleListDTO.java
@@ -17,11 +17,11 @@ public class VehicleListDTO {
         vehicles.put(vehicle.getLabel(), new VehicleDTO(vehicle));
     }
 
-    public void addVehicle(String label, LocationDTO location, VehicleType type){
+    public void addVehicle(String label, RoadLocationDTO location, VehicleType type){
         vehicles.put(label, new VehicleDTO(label, location, type));
     }
 
-    public void addVehicle(String label, LocationDTO location, VehicleType type, float speed){
+    public void addVehicle(String label, RoadLocationDTO location, VehicleType type, float speed){
         vehicles.put(label, new VehicleDTO(label, speed, location, type));
     }
 
@@ -33,8 +33,8 @@ public class VehicleListDTO {
         vehicles.get(label).setSpeed(newSpeed);
     }
 
-    public void setVehicleLocation(String label, LocationDTO newLocation){
-        vehicles.get(label).setLocation(new LocationDTO(newLocation));
+    public void setVehicleLocation(String label, RoadLocationDTO newLocation){
+        vehicles.get(label).setLocation(new RoadLocationDTO(newLocation));
     }
 
     public List<VehicleDTO> getAll(){

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleStateChangeListener.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleStateChangeListener.java
@@ -1,18 +1,21 @@
 package thewaypointers.trafficsimulator.common.helpers;
 
-import thewaypointers.trafficsimulator.common.IStateChangeListener;
-import thewaypointers.trafficsimulator.common.LocationDTO;
-import thewaypointers.trafficsimulator.common.WorldStateDTO;
+import thewaypointers.trafficsimulator.common.*;
 
 public class SimpleStateChangeListener implements IStateChangeListener{
 
     @Override
     public void NewStateReceived(WorldStateDTO state) {
-        LocationDTO loc = state.getVehicleList().getAll().get(0).getLocation();
-        System.out.format("Vehicle 0 position: %f en route from %s to %s",
-                          loc.getDistanceTravelled(),
-                          loc.getRoad().getFrom().getLabel(),
-                          loc.getRoad().getTo().getLabel());
+        ILocation location = state.getVehicleList().getAll().get(0).getLocation();
+        if (location.getClass().equals(JunctionLocationDTO.class)){
+            System.out.format("Vehicle 0: at junction");
+        }else if(location.getClass().equals(RoadLocationDTO.class)){
+            RoadLocationDTO loc = (RoadLocationDTO) location;
+            System.out.format("Vehicle 0 position: %f en route from %s to %s",
+                              loc.getDistanceTravelled(),
+                              loc.getRoad().getFrom().getLabel(),
+                              loc.getRoad().getTo().getLabel());
+        }
         System.out.println();
     }
 }

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldState.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldState.java
@@ -1,0 +1,7 @@
+package thewaypointers.trafficsimulator.common.helpers;
+
+public enum SimpleWorldState {
+    FIRST_VERSION,
+    ROAD_NETWORK,
+    JUNCTION_TEST
+}

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldState.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldState.java
@@ -3,5 +3,5 @@ package thewaypointers.trafficsimulator.common.helpers;
 public enum SimpleWorldState {
     FIRST_VERSION,
     ROAD_NETWORK,
-    JUNCTION_TEST
+    JUNCTION_LOCATION_TEST
 }

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldStateProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldStateProvider.java
@@ -29,7 +29,7 @@ public class SimpleWorldStateProvider {
         ws.getTrafficLightSystem().addJunction(roadMap.getJunction("A"));
 
         RoadDTO startRoad = roadMap.getJunction("A").getRoad(Direction.Up);
-        LocationDTO loc = new LocationDTO(startRoad, startRoad.getEnd("E1"), 0, Lane.Right);
+        RoadLocationDTO loc = new RoadLocationDTO(startRoad, startRoad.getEnd("E1"), 0, Lane.Right);
         ws.getVehicleList().addVehicle("V1", loc, VehicleType.CarNormal);
 
         return ws;
@@ -58,13 +58,13 @@ public class SimpleWorldStateProvider {
 
         // add cars
         RoadDTO startRoad = roadMap.getJunction("A").getRoad(Direction.Up);
-        LocationDTO loc = new LocationDTO(startRoad, startRoad.getEnd("E1"), 0, Lane.Right);
+        RoadLocationDTO loc = new RoadLocationDTO(startRoad, startRoad.getEnd("E1"), 0, Lane.Right);
         RoadDTO startRoad2 = roadMap.getJunction("A").getRoad(Direction.Left);
-        LocationDTO loc2 = new LocationDTO(startRoad2, startRoad2.getEnd("E3"), 0, Lane.Right);
+        RoadLocationDTO loc2 = new RoadLocationDTO(startRoad2, startRoad2.getEnd("E3"), 0, Lane.Right);
         RoadDTO startRoad3 = roadMap.getJunction("B").getRoad(Direction.Right);
-        LocationDTO loc3 = new LocationDTO(startRoad3, startRoad3.getEnd("B"), 0, Lane.Right);
+        RoadLocationDTO loc3 = new RoadLocationDTO(startRoad3, startRoad3.getEnd("B"), 0, Lane.Right);
         RoadDTO startRoad4 = roadMap.getJunction("B").getRoad(Direction.Down);
-        LocationDTO loc4 = new LocationDTO(startRoad4, startRoad4.getEnd("E7"), 0, Lane.Right);
+        RoadLocationDTO loc4 = new RoadLocationDTO(startRoad4, startRoad4.getEnd("E7"), 0, Lane.Right);
         ws.getVehicleList().addVehicle("V1", loc, VehicleType.CarNormal);
         ws.getVehicleList().addVehicle("V2", loc2, VehicleType.EmergencyService);
         ws.getVehicleList().addVehicle("V3", loc3, VehicleType.Bus);
@@ -79,22 +79,22 @@ public class SimpleWorldStateProvider {
         RoadDTO downRoad = junction.getRoad(Direction.Down);
         RoadDTO upRoad = junction.getRoad(Direction.Up);
         VehicleDTO v = worldState.getVehicleList().getAll().get(0);
-        LocationDTO loc = v.getLocation();
+        RoadLocationDTO loc = (RoadLocationDTO) v.getLocation();
         if(vehicleMovement > ROAD_LENGTH)
             throw new IllegalArgumentException("Cannot pass vehicleMovement bigger than the length of the road");
 
         stateNo++;
 
-        LocationDTO newLocation;
+        RoadLocationDTO newLocation;
         if (loc.getDistanceTravelled() + vehicleMovement < loc.getRoad().getLength()) {
-            newLocation = new LocationDTO(loc.getRoad(),
+            newLocation = new RoadLocationDTO(loc.getRoad(),
                     loc.getOrigin(),
                     loc.getDistanceTravelled() + vehicleMovement,
                     loc.getLane());
         }else{
             // jump to next road
             RoadDTO newRoad = loc.getRoad().equals(upRoad) ? downRoad : upRoad;
-            newLocation = new LocationDTO(newRoad,
+            newLocation = new RoadLocationDTO(newRoad,
                     newRoad.getFrom(),
                     loc.getDistanceTravelled() + vehicleMovement - loc.getRoad().getLength(),
                     loc.getLane());

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldStateProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/SimpleWorldStateProvider.java
@@ -6,16 +6,22 @@ public class SimpleWorldStateProvider {
     public static final float ROAD_LENGTH = 300;
     public static final int CHANGE_LIGHTS_EVERY_N_STATES = 1;
 
-    WorldStateDTO roadNetworkWorldState;
-    WorldStateDTO firstVersionWorldState;
-    
-    public boolean roadNetwork = true;
+    WorldStateDTO worldState;
     
     private int stateNo;
 
-    public SimpleWorldStateProvider(){
-        firstVersionWorldState = initializeFirstVersionWorldState();
-        roadNetworkWorldState = initializeRoadNetworkWorldState();
+    public SimpleWorldStateProvider(SimpleWorldState state){
+        switch(state){
+            case FIRST_VERSION:
+                worldState = initializeFirstVersionWorldState();
+                break;
+            case ROAD_NETWORK:
+                worldState = initializeRoadNetworkWorldState();
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "No logic implemented for specified state!");
+        }
     }
     
     private WorldStateDTO initializeFirstVersionWorldState(){
@@ -73,8 +79,7 @@ public class SimpleWorldStateProvider {
     }
 
     public WorldStateDTO getNextState(float vehicleMovement) {
-        
-        WorldStateDTO worldState = roadNetwork? roadNetworkWorldState : firstVersionWorldState;
+
         JunctionDTO junction = worldState.getRoadMap().getJunctions().get(0);
         RoadDTO downRoad = junction.getRoad(Direction.Down);
         RoadDTO upRoad = junction.getRoad(Direction.Up);

--- a/src/main/java/thewaypointers/trafficsimulator/gui/MapPanel.java
+++ b/src/main/java/thewaypointers/trafficsimulator/gui/MapPanel.java
@@ -73,11 +73,14 @@ public class MapPanel extends JPanel implements IStateChangeListener{
     }
 
     private void draw_Vehicle(Graphics g, VehicleDTO vehicle,MapDTO map){
+        if (vehicle.getLocation().getClass() != RoadLocationDTO.class)
+            return;
+        RoadLocationDTO location = (RoadLocationDTO) vehicle.getLocation();
         Color color=Color.white;
         int wide,length;
         VehicleType type=vehicle.getType();
-        Direction road_direction=this.Getcar_roadedirection(map,vehicle.getLocation());
-        Point point=this.compute_xy(map,vehicle.getLocation());
+        Direction road_direction=this.Getcar_roadedirection(map, location);
+        Point point=this.compute_xy(map,location);
         switch (type) {
             case CarNormal:
                 color=VEHICLE_CarNormal_COLOR;
@@ -310,7 +313,7 @@ public class MapPanel extends JPanel implements IStateChangeListener{
     }
 
     // computer vehicle x&y base on location
-    public  Point compute_xy(MapDTO roadmap,LocationDTO locationDTO){
+    public  Point compute_xy(MapDTO roadmap,RoadLocationDTO locationDTO){
         Point point = new Point();
         double px = 0, py = 0;
         RoadDTO roadDTO = locationDTO.getRoad();
@@ -431,8 +434,8 @@ public class MapPanel extends JPanel implements IStateChangeListener{
         return  point;
     }
 
-    public Direction Getcar_roadedirection(MapDTO road_map,LocationDTO locationDTO){
-        RoadDTO roadDTO=locationDTO.getRoad();
+    public Direction Getcar_roadedirection(MapDTO road_map,RoadLocationDTO roadLocationDTO){
+        RoadDTO roadDTO= roadLocationDTO.getRoad();
         Direction road_direction=null;
         String junction_label;
         if (junctionlocation.containsKey(roadDTO.getFrom().getLabel())){

--- a/src/main/java/thewaypointers/trafficsimulator/simulation/Simulation.java
+++ b/src/main/java/thewaypointers/trafficsimulator/simulation/Simulation.java
@@ -87,7 +87,7 @@ public class Simulation implements ISimulationInputListener {
         for (DefaultWeightedEdge road : VehicleManager.getVehicleMap().keySet()) {
             for (IVehicle vehicle : VehicleManager.getVehicleMap().get(road)) {
                 RoadDTO roadDTO = findEqualRoad(vehicle.getVehiclesOriginNode() + vehicle.getVehiclesDestinationNode());
-                LocationDTO loc = new LocationDTO(roadDTO, roadDTO.getEnd(vehicle.getVehiclesOriginNode()), vehicle.getVehiclesDistanceTravelled(), Lane.Right);
+                RoadLocationDTO loc = new RoadLocationDTO(roadDTO, roadDTO.getEnd(vehicle.getVehiclesOriginNode()), vehicle.getVehiclesDistanceTravelled(), Lane.Right);
                 dtoVehicleList.addVehicle("" + index, loc, VehicleType.CarNormal);
                 index++;
             }

--- a/src/main/java/thewaypointers/trafficsimulator/utils/Angle.java
+++ b/src/main/java/thewaypointers/trafficsimulator/utils/Angle.java
@@ -1,0 +1,22 @@
+package thewaypointers.trafficsimulator.utils;
+
+public class Angle {
+
+    public static double rotate90(double angle, Rotation rotation){
+        return rotation == Rotation.Counterclockwise?
+                add(angle, Math.PI/2) :
+                subtract(angle, Math.PI/2);
+
+    }
+
+    public static double add(double angle1, double angle2){
+        return (angle1+angle2) % (2*Math.PI);
+    }
+
+    public static double subtract(double angle1, double angle2){
+        angle1 = angle1 % (Math.PI*2);
+        angle2 = angle2 % (Math.PI*2);
+        double result = angle1 - angle2;
+        return result < 0? (Math.PI*2)+result : result;
+    }
+}

--- a/src/main/java/thewaypointers/trafficsimulator/utils/FloatPoint.java
+++ b/src/main/java/thewaypointers/trafficsimulator/utils/FloatPoint.java
@@ -1,8 +1,5 @@
 package thewaypointers.trafficsimulator.utils;
 
-import sun.font.StrikeCache;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
-
 public class FloatPoint {
     private float x;
     private float y;

--- a/src/main/java/thewaypointers/trafficsimulator/utils/FloatPoint.java
+++ b/src/main/java/thewaypointers/trafficsimulator/utils/FloatPoint.java
@@ -1,0 +1,65 @@
+package thewaypointers.trafficsimulator.utils;
+
+import sun.font.StrikeCache;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+public class FloatPoint {
+    private float x;
+    private float y;
+
+    public FloatPoint() { this(0,0); }
+
+    public FloatPoint(float x, float y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public float getX() {
+        return x;
+    }
+
+    public float getY() {
+        return y;
+    }
+
+    public FloatPoint rotate90(FloatPoint center, Rotation rotation)
+    {
+        FloatPoint n = this.subtract(center);
+        FloatPoint rotated = rotation == Rotation.Clockwise?
+                             new FloatPoint(n.getY(), -n.getX()) :
+                             new FloatPoint(-n.getY(), n.getX());
+        return rotated.add(center);
+    }
+
+    public FloatPoint mirror(FloatPoint center){
+        return this
+                .rotate90(center, Rotation.Clockwise)
+                .rotate90(center, Rotation.Clockwise);
+    }
+
+    public boolean equals(FloatPoint other){
+        return  getX() == other.getX() &&
+                getY() == other.getY();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return  o.getClass()==FloatPoint.class &&
+                equals((FloatPoint)o);
+    }
+
+    public FloatPoint add(FloatPoint other){
+        return new FloatPoint(getX()+other.getX(),
+                              getY()+other.getY());
+    }
+
+    public FloatPoint subtract(FloatPoint other){
+        return new FloatPoint(getX()-other.getX(),
+                              getY()-other.getY());
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Point(%f,%f)", getX(), getY());
+    }
+}

--- a/src/main/java/thewaypointers/trafficsimulator/utils/Rotation.java
+++ b/src/main/java/thewaypointers/trafficsimulator/utils/Rotation.java
@@ -1,0 +1,6 @@
+package thewaypointers.trafficsimulator.utils;
+
+public enum Rotation {
+    Clockwise,
+    Counterclockwise
+}

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
@@ -3,12 +3,10 @@ package thewaypointers.trafficsimulator.tests.common;
 import org.fest.assertions.data.Offset;
 import org.junit.Test;
 import thewaypointers.trafficsimulator.common.Direction;
-import thewaypointers.trafficsimulator.common.JunctionDTO;
 import thewaypointers.trafficsimulator.common.JunctionLocationDTO;
 import thewaypointers.trafficsimulator.common.JunctionMoveResult;
 import thewaypointers.trafficsimulator.utils.FloatPoint;
 
-import static org.junit.Assert.*;
 import static org.fest.assertions.api.Assertions.*;
 
 public class JunctionLocationDTOTest {
@@ -53,7 +51,7 @@ public class JunctionLocationDTOTest {
     }
 
     @Test
-    public void testGetPercentageTravelled() {
+    public void testGetProgress() {
         // arrange
         JunctionLocationDTO loc = new JunctionLocationDTO(
                 "A",
@@ -62,7 +60,7 @@ public class JunctionLocationDTOTest {
                 0.5f);
 
         // act and assert
-        assertThat(loc.getPercentageTravelled()).isEqualTo(0.5f);
+        assertThat(loc.getProgress()).isEqualTo(0.5f);
     }
 
     @Test
@@ -428,7 +426,7 @@ public class JunctionLocationDTOTest {
         JunctionMoveResult result = loc.move(0.5f, 1, 1);
 
         // assert
-        assertThat(result.getNewLocation().getPercentageTravelled())
+        assertThat(result.getNewLocation().getProgress())
                 .isEqualTo(0.75f, Offset.offset(0.0001f));
     }
 
@@ -445,7 +443,7 @@ public class JunctionLocationDTOTest {
         JunctionMoveResult result = loc.move(0.25f, 1, 1);
 
         // assert
-        assertThat(result.getNewLocation().getPercentageTravelled())
+        assertThat(result.getNewLocation().getProgress())
                 .isEqualTo(0.75f, Offset.offset(0.0001f));
     }
 
@@ -461,7 +459,7 @@ public class JunctionLocationDTOTest {
         JunctionMoveResult result = loc.move(0.3f, 1, 1);
 
         // assert
-        assertThat(result.getNewLocation().getPercentageTravelled())
+        assertThat(result.getNewLocation().getProgress())
                 .isEqualTo(0.45f, Offset.offset(0.0001f));
     }
 
@@ -478,7 +476,7 @@ public class JunctionLocationDTOTest {
         JunctionMoveResult result = loc.move(0.5f, 1, 1);
 
         // assert
-        assertThat(result.getNewLocation().getPercentageTravelled())
+        assertThat(result.getNewLocation().getProgress())
                 .isEqualTo(1f, Offset.offset(0.0001f));
         assertThat(result.getRemainder()).isEqualTo(0.25f, Offset.offset(0.0001f));
     }
@@ -496,7 +494,7 @@ public class JunctionLocationDTOTest {
         JunctionMoveResult result = loc.move(2f, 2, 2);
 
         // assert
-        assertThat(result.getNewLocation().getPercentageTravelled())
+        assertThat(result.getNewLocation().getProgress())
                 .isEqualTo(1f, Offset.offset(0.0001f));
         assertThat(result.getRemainder()).isEqualTo(1f, Offset.offset(0.0001f));
     }

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
@@ -1,0 +1,82 @@
+package thewaypointers.trafficsimulator.tests.common;
+
+import org.junit.Test;
+import thewaypointers.trafficsimulator.common.Direction;
+import thewaypointers.trafficsimulator.common.JunctionDTO;
+import thewaypointers.trafficsimulator.common.JunctionLocationDTO;
+
+import static org.junit.Assert.*;
+import static org.fest.assertions.api.Assertions.*;
+
+public class JunctionLocationDTOTest {
+
+    @Test
+    public void testGetJunctionLabel() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.getJunctionLabel()).isEqualTo("A");
+    }
+
+    @Test
+    public void testGetOrigin() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.getOrigin()).isEqualTo(Direction.Down);
+    }
+
+    @Test
+    public void testGetTarget() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.getTarget()).isEqualTo(Direction.Up);
+    }
+
+    @Test
+    public void testGetPercentageTravelled() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.getPercentageTravelled()).isEqualTo(0.5f);
+    }
+
+    @Test
+    public void testCopy() throws Exception {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.copy()).isEqualTo(loc);
+    }
+
+    @Test
+    public void testGetJunctionCoordinates() {
+
+    }
+}

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import thewaypointers.trafficsimulator.common.Direction;
 import thewaypointers.trafficsimulator.common.JunctionDTO;
 import thewaypointers.trafficsimulator.common.JunctionLocationDTO;
+import thewaypointers.trafficsimulator.common.JunctionMoveResult;
 import thewaypointers.trafficsimulator.utils.FloatPoint;
 
 import static org.junit.Assert.*;
@@ -414,4 +415,89 @@ public class JunctionLocationDTOTest {
         assertThat(loc.getAngle()).isEqualTo(Math.PI, Offset.offset(0.0001));
     }
 
+    @Test
+    public void testMove_straightRoute(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.25f);
+
+        // act
+        JunctionMoveResult result = loc.move(0.5f, 1, 1);
+
+        // assert
+        assertThat(result.getNewLocation().getPercentageTravelled())
+                .isEqualTo(0.75f, Offset.offset(0.0001f));
+    }
+
+    @Test
+    public void testMove_RightTurn(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Right,
+                0.25f);
+
+        // act
+        JunctionMoveResult result = loc.move(0.25f, 1, 1);
+
+        // assert
+        assertThat(result.getNewLocation().getPercentageTravelled())
+                .isEqualTo(0.75f, Offset.offset(0.0001f));
+    }
+
+    public void testMove_LeftTurn(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.25f);
+
+        // act
+        JunctionMoveResult result = loc.move(0.3f, 1, 1);
+
+        // assert
+        assertThat(result.getNewLocation().getPercentageTravelled())
+                .isEqualTo(0.45f, Offset.offset(0.0001f));
+    }
+
+    @Test
+    public void testMove_remainder(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.75f);
+
+        // act
+        JunctionMoveResult result = loc.move(0.5f, 1, 1);
+
+        // assert
+        assertThat(result.getNewLocation().getPercentageTravelled())
+                .isEqualTo(1f, Offset.offset(0.0001f));
+        assertThat(result.getRemainder()).isEqualTo(0.25f, Offset.offset(0.0001f));
+    }
+
+    @Test
+    public void testMove_scaleJunction(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.5f);
+
+        // act
+        JunctionMoveResult result = loc.move(2f, 2, 2);
+
+        // assert
+        assertThat(result.getNewLocation().getPercentageTravelled())
+                .isEqualTo(1f, Offset.offset(0.0001f));
+        assertThat(result.getRemainder()).isEqualTo(1f, Offset.offset(0.0001f));
+    }
 }

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
@@ -1,9 +1,11 @@
 package thewaypointers.trafficsimulator.tests.common;
 
+import org.fest.assertions.data.Offset;
 import org.junit.Test;
 import thewaypointers.trafficsimulator.common.Direction;
 import thewaypointers.trafficsimulator.common.JunctionDTO;
 import thewaypointers.trafficsimulator.common.JunctionLocationDTO;
+import thewaypointers.trafficsimulator.utils.FloatPoint;
 
 import static org.junit.Assert.*;
 import static org.fest.assertions.api.Assertions.*;
@@ -63,7 +65,7 @@ public class JunctionLocationDTOTest {
     }
 
     @Test
-    public void testCopy() throws Exception {
+    public void testCopy() {
         // arrange
         JunctionLocationDTO loc = new JunctionLocationDTO(
                 "A",
@@ -76,7 +78,210 @@ public class JunctionLocationDTOTest {
     }
 
     @Test
-    public void testGetJunctionCoordinates() {
+    public void testGetJunctionCoordinates_StraightRoute() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.75f);
 
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.75f, 0.25f));
     }
+
+    @Test
+    public void testGetJunctionCoordinates_StraightRoute_minprogress() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.75f, 1f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_StraightRoute_maxprogress() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                1f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.75f, 0f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_RightTurn_minprogress() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.75f, 1f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_RightTurn_maxprogress() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Right,
+                1f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(1f, 0.75f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_RightTurn_middle() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Right,
+                0.5f);
+
+        // act
+        FloatPoint coords = loc.getJunctionCoordinates();
+
+        // assert
+        assertThat(coords.getX()).isGreaterThan(0.75f);
+        assertThat(coords.getX()).isLessThan(1f);
+        assertThat(coords.getY()).isGreaterThan(0.75f);
+        assertThat(coords.getY()).isLessThan(1f);
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_LeftTurn_minprogress() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.75f, 1f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_LeftTurn_maxprogress() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                1f);
+
+        // act
+        FloatPoint coords = loc.getJunctionCoordinates();
+
+        // assert
+        assertThat(coords.getX()).isEqualTo(0, Offset.offset(0.0001f));
+        assertThat(coords.getY()).isEqualTo(0.25f, Offset.offset(0.0001f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_LeftTurn_middle() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.5f);
+
+        // act
+        FloatPoint coords = loc.getJunctionCoordinates();
+
+        // assert
+        assertThat(coords.getX()).isGreaterThan(0.5f);
+        assertThat(coords.getX()).isLessThan(0.75f);
+        assertThat(coords.getY()).isGreaterThan(0.25f);
+        assertThat(coords.getY()).isLessThan(0.5f);
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_LeftTurn_FirstSection() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.25f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates().getX()).isEqualTo(0.75f);
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_LeftTurn_LastSection() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.75f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates().getY()).isEqualTo(0.25f);
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_originLeft() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Left,
+                Direction.Right,
+                0.75f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.75f, 0.75f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_originUp() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Up,
+                Direction.Down,
+                0.75f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.25f, 0.75f));
+    }
+
+    @Test
+    public void testGetJunctionCoordinates_originRight() {
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Right,
+                Direction.Left,
+                0.75f);
+
+        // act and assert
+        assertThat(loc.getJunctionCoordinates())
+                .isEqualTo(new FloatPoint(0.25f, 0.25f));
+    }
+
 }

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/JunctionLocationDTOTest.java
@@ -284,4 +284,134 @@ public class JunctionLocationDTOTest {
                 .isEqualTo(new FloatPoint(0.25f, 0.25f));
     }
 
+    @Test
+    public void testGetAngle_straightRoute(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Up,
+                0.75f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(Math.PI/2, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_rightTurn_start(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Right,
+                0f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(Math.PI/2, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_rightTurn_end(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Right,
+                1f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(0, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_rightTurn_middle(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Right,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(Math.PI/4, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_leftTurn_firstSection(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.25f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(Math.PI/2, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_leftTurn_middle(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.5f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo((3/4f)*Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_leftTurn_lastSection(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Down,
+                Direction.Left,
+                0.75f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_originLeft(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Left,
+                Direction.Right,
+                0.25f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(0, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_originUp(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Up,
+                Direction.Down,
+                0.25f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo((3/2f)*Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testGetAngle_originRight(){
+        // arrange
+        JunctionLocationDTO loc = new JunctionLocationDTO(
+                "A",
+                Direction.Right,
+                Direction.Left,
+                0.25f);
+
+        // act and assert
+        assertThat(loc.getAngle()).isEqualTo(Math.PI, Offset.offset(0.0001));
+    }
+
 }

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionWorldStateProviderTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionWorldStateProviderTest.java
@@ -3,6 +3,7 @@ package thewaypointers.trafficsimulator.tests.common.helpers;
 import static org.fest.assertions.api.Assertions.*;
 import org.junit.Test;
 import thewaypointers.trafficsimulator.common.*;
+import thewaypointers.trafficsimulator.common.helpers.SimpleWorldState;
 import thewaypointers.trafficsimulator.common.helpers.SimpleWorldStateProvider;
 
 public class FirstVersionWorldStateProviderTest {

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionWorldStateProviderTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionWorldStateProviderTest.java
@@ -4,14 +4,14 @@ import static org.fest.assertions.api.Assertions.*;
 import org.junit.Test;
 import thewaypointers.trafficsimulator.common.*;
 import thewaypointers.trafficsimulator.common.VehicleType;
+import thewaypointers.trafficsimulator.common.helpers.SimpleWorldState;
 import thewaypointers.trafficsimulator.common.helpers.SimpleWorldStateProvider;
 
-public class SimpleWorldStateProviderTest {
+public class FirstVersionWorldStateProviderTest {
     @Test
     public void Provider_generates_correct_world_state() {
         // arrange
-        SimpleWorldStateProvider provider = new SimpleWorldStateProvider();
-        provider.roadNetwork = false;
+        SimpleWorldStateProvider provider = new SimpleWorldStateProvider(SimpleWorldState.FIRST_VERSION);
 
         // act
         WorldStateDTO worldState = provider.getNextState(15);
@@ -54,9 +54,8 @@ public class SimpleWorldStateProviderTest {
     public void Provider_moves_vehicle()
     {
         // arrange
-        SimpleWorldStateProvider provider = new SimpleWorldStateProvider();
+        SimpleWorldStateProvider provider = new SimpleWorldStateProvider(SimpleWorldState.FIRST_VERSION);
         final float moveDistance = SimpleWorldStateProvider.ROAD_LENGTH/30;
-        provider.roadNetwork = false;
 
         // act
         WorldStateDTO ws1 = provider.getNextState(moveDistance);
@@ -74,9 +73,8 @@ public class SimpleWorldStateProviderTest {
     public void Vehicle_jumps_from_up_to_down_road()
     {
         // arrange
-        SimpleWorldStateProvider provider = new SimpleWorldStateProvider();
+        SimpleWorldStateProvider provider = new SimpleWorldStateProvider(SimpleWorldState.FIRST_VERSION);
         final float moveDistance = SimpleWorldStateProvider.ROAD_LENGTH/2;
-        provider.roadNetwork = false;
 
         // act
         provider.getNextState(moveDistance);
@@ -92,9 +90,8 @@ public class SimpleWorldStateProviderTest {
     public void Vehicle_loops_back_to_up_road()
     {
         // arrange
-        SimpleWorldStateProvider provider = new SimpleWorldStateProvider();
+        SimpleWorldStateProvider provider = new SimpleWorldStateProvider(SimpleWorldState.FIRST_VERSION);
         final float moveDistance = SimpleWorldStateProvider.ROAD_LENGTH/2;
-        provider.roadNetwork = false;
 
         // act
         provider.getNextState(moveDistance);
@@ -111,8 +108,7 @@ public class SimpleWorldStateProviderTest {
     @Test
     public void Traffic_lights_change(){
         // arrange
-        SimpleWorldStateProvider provider = new SimpleWorldStateProvider();
-        provider.roadNetwork = false;
+        SimpleWorldStateProvider provider = new SimpleWorldStateProvider(SimpleWorldState.FIRST_VERSION);
 
         // act
         WorldStateDTO worldState = provider.getNextState(15);

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/SimpleWorldStateProviderTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/SimpleWorldStateProviderTest.java
@@ -42,7 +42,7 @@ public class SimpleWorldStateProviderTest {
         VehicleDTO v = worldState.getVehicleList().getAll().get(0);
         assertThat(v.getType()).isEqualTo(VehicleType.CarNormal);
 
-        LocationDTO loc = v.getLocation();
+        RoadLocationDTO loc = (RoadLocationDTO) v.getLocation();
         assertThat(loc.getLane()).isEqualTo(Lane.Right);
         assertThat(loc.getRoad().equals(downRoad));
         assertThat(loc.getOrigin().getLabel().equals("E1"));
@@ -60,9 +60,9 @@ public class SimpleWorldStateProviderTest {
 
         // act
         WorldStateDTO ws1 = provider.getNextState(moveDistance);
-        LocationDTO loc1 = ws1.getVehicleList().getAll().get(0).getLocation();
+        RoadLocationDTO loc1 = (RoadLocationDTO) ws1.getVehicleList().getAll().get(0).getLocation();
         WorldStateDTO ws2 = provider.getNextState(moveDistance);
-        LocationDTO loc2 = ws2.getVehicleList().getAll().get(0).getLocation();
+        RoadLocationDTO loc2 = (RoadLocationDTO) ws2.getVehicleList().getAll().get(0).getLocation();
 
         // assert
         assertThat(loc1 != loc2).isTrue();
@@ -83,7 +83,7 @@ public class SimpleWorldStateProviderTest {
         WorldStateDTO worldState = provider.getNextState(moveDistance);
 
         // assert
-        LocationDTO loc = worldState.getVehicleList().getAll().get(0).getLocation();
+        RoadLocationDTO loc = (RoadLocationDTO)worldState.getVehicleList().getAll().get(0).getLocation();
         RoadDTO downRoad = worldState.getRoadMap().getJunctions().get(0).getRoad(Direction.Down);
         assertThat(loc.getRoad()).isEqualTo(downRoad);
     }
@@ -103,7 +103,7 @@ public class SimpleWorldStateProviderTest {
         WorldStateDTO worldState = provider.getNextState(moveDistance);
 
         // assert
-        LocationDTO loc = worldState.getVehicleList().getAll().get(0).getLocation();
+        RoadLocationDTO loc = (RoadLocationDTO) worldState.getVehicleList().getAll().get(0).getLocation();
         RoadDTO upRoad = worldState.getRoadMap().getJunctions().get(0).getRoad(Direction.Up);
         assertThat(loc.getRoad()).isEqualTo(upRoad);
     }

--- a/src/test/java/thewaypointers/trafficsimulator/tests/utils/FloatPointTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/utils/FloatPointTest.java
@@ -1,0 +1,118 @@
+package thewaypointers.trafficsimulator.tests.utils;
+
+import org.junit.Test;
+import thewaypointers.trafficsimulator.utils.FloatPoint;
+import thewaypointers.trafficsimulator.utils.Rotation;
+
+import static org.fest.assertions.api.Assertions.*;
+
+public class FloatPointTest {
+
+    @Test
+    public void testGetX() {
+        // arrange and act
+        float x = 99;
+        float y = 88;
+        FloatPoint point = new FloatPoint(x,y);
+
+        // assert
+        assertThat(point.getX()).isEqualTo(x);
+    }
+
+    @Test
+    public void testGetY()  {
+        // arrange and act
+        float x = 99;
+        float y = 88;
+        FloatPoint point = new FloatPoint(x,y);
+
+        // assert
+        assertThat(point.getY()).isEqualTo(y);
+    }
+
+    @Test
+    public void testEquals(){
+        // arrange
+        FloatPoint p1 = new FloatPoint(2,3);
+        FloatPoint p2 = new FloatPoint(2,3);
+
+        // act and assert
+        assertThat(p1.equals(p2)).isTrue();
+    }
+
+    @Test
+    public void testObjectEquals(){
+        // arrange
+        FloatPoint p1 = new FloatPoint(2,3);
+        FloatPoint p2 = new FloatPoint(2,3);
+
+        // act and assert
+        assertThat(p1.equals((Object)p2)).isTrue();
+    }
+
+    @Test
+    public void testAdd(){
+        // arrange
+        FloatPoint p1 = new FloatPoint(2.5f,3);
+        FloatPoint p2 = new FloatPoint(1,1);
+
+        // act
+        FloatPoint result = p1.add(p2);
+
+        // assert
+        assertThat(result).isEqualTo(new FloatPoint(3.5f,4));
+    }
+
+    @Test
+    public void testSubtract(){
+        // arrange
+        FloatPoint p1 = new FloatPoint(1.5f,1);
+        FloatPoint p2 = new FloatPoint(2,3);
+
+        // act
+        FloatPoint result = p1.subtract(p2);
+
+        // assert
+        assertThat(result).isEqualTo(new FloatPoint(-0.5f,-2));
+    }
+
+    @Test
+    public void testRotate90_counterclockwise() {
+        // arrange
+        FloatPoint center = new FloatPoint(1,2);
+        FloatPoint point = new FloatPoint(3,3);
+
+        // act
+        FloatPoint result = point.rotate90(center, Rotation.Counterclockwise);
+
+        // assert
+        assertThat(result).isEqualTo(new FloatPoint(0,4));
+    }
+
+    @Test
+    public void testRotate90_clockwise() {
+        // arrange
+        FloatPoint center = new FloatPoint(1,2);
+        FloatPoint point = new FloatPoint(3,3);
+
+        // act
+        FloatPoint result = point.rotate90(center, Rotation.Clockwise);
+
+        // assert
+        assertThat(result).isEqualTo(new FloatPoint(2,0));
+    }
+
+    @Test
+    public void testMirror(){
+        // arrange
+        FloatPoint center = new FloatPoint(1,2);
+        FloatPoint point = new FloatPoint(3,3);
+
+        // act
+        FloatPoint result = point.mirror(center);
+
+        // assert
+        assertThat(result).isEqualTo(new FloatPoint(-1,1));
+    }
+
+}

--- a/src/test/java/thewaypointers/trafficsimulator/utils/AngleTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/utils/AngleTest.java
@@ -1,0 +1,45 @@
+package thewaypointers.trafficsimulator.utils;
+
+import org.fest.assertions.data.Offset;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.fest.assertions.api.Assertions.*;
+
+public class AngleTest {
+
+    @Test
+    public void testAdd(){
+        assertThat(Angle.add(
+                (7/4f)*Math.PI, (1/2f)*Math.PI
+        )).isEqualTo((1/4f)*Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testSubtract(){
+        assertThat(Angle.subtract(
+                (1/4f)*Math.PI, (1/2f)*Math.PI
+        )).isEqualTo((7/4f)*Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testSubtract2(){
+        assertThat(Angle.subtract(
+                (1/2f)*Math.PI, (1/4f)*Math.PI
+        )).isEqualTo((1/4f)*Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testRotate90_counterclockwise() {
+        assertThat(Angle.rotate90(
+                (7/4f)*Math.PI, Rotation.Counterclockwise
+        )).isEqualTo((1/4f)*Math.PI, Offset.offset(0.0001));
+    }
+
+    @Test
+    public void testRotate90_clockwise() {
+        assertThat(Angle.rotate90(
+                (1/4f)*Math.PI, Rotation.Clockwise
+        )).isEqualTo((7/4f)*Math.PI, Offset.offset(0.0001));
+    }
+}


### PR DESCRIPTION
Closes #21.

I added:
* the `JunctionLocationDTO` class. It's documented in the code, along with its three main methods: `getJunctionCoordinates()`, `getAngle()`, and `move()`.
* lots of tests for the class
* some helper classes
* new starter class, `JunctionLocationTestStarter`. You can use it to see an example of a vehicle moving inside junction.

Now, `VehicleDTO` contains a field of type `ILocation` instead of `LocationDTO`, which got renamed to `RoadLocationDTO`. When getting the location, you should check whether what you got is `RoadLocationDTO` or `JunctionLocationDTO` and then cast to aproppriate class. There are examples in the GUI code for example, since I had to modify it for it to work.

I will upload drawings later to the wiki, although the docs in code and the example inside `SimpleWorldStateProvider` should be enough to understand and use.