### PR TITLE
Add clock to WorldStateDTO

### DIFF
--- a/TrafficSimulator.iml
+++ b/TrafficSimulator.iml
@@ -11,13 +11,6 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: org.easytesting:fest-assert-core:2.0M5" level="project" />
-    <orderEntry type="library" name="Maven: org.easytesting:fest-util:1.2.0" level="project" />
-    <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
-    <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
-    <orderEntry type="library" name="Maven: org.jgrapht:jgrapht-jdk1.5:0.7.3" level="project" />
-    <orderEntry type="library" name="Maven: org.easytesting:fest-assert-core:2.0M5" level="project" />
-    <orderEntry type="library" name="Maven: org.easytesting:fest-util:1.2.0" level="project" />
     <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" name="Maven: org.jgrapht:jgrapht-jdk1.5:0.7.3" level="project" />

--- a/src/main/java/thewaypointers/trafficsimulator/common/WorldStateDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/WorldStateDTO.java
@@ -1,6 +1,7 @@
 package thewaypointers.trafficsimulator.common;
 
 public class WorldStateDTO {
+    private float clock;
     private MapDTO roadMap;
     private VehicleListDTO vehicleList;
     private TrafficLightSystemDTO trafficLightSystem;
@@ -9,12 +10,21 @@ public class WorldStateDTO {
         this.roadMap = new MapDTO();
         this.vehicleList = new VehicleListDTO();
         this.trafficLightSystem = new TrafficLightSystemDTO();
+        this.clock = 0;
     }
 
     public WorldStateDTO(MapDTO roadMap, VehicleListDTO vehicles, TrafficLightSystemDTO trafficLightSystem) {
         this.roadMap = roadMap;
         this.vehicleList = vehicles;
         this.trafficLightSystem = trafficLightSystem;
+    }
+
+    public WorldStateDTO(MapDTO roadMap,
+                         VehicleListDTO vehicles,
+                         TrafficLightSystemDTO trafficLightSystem,
+                         float clock){
+        this(roadMap, vehicles, trafficLightSystem);
+        this.clock = clock;
     }
 
     public MapDTO getRoadMap() {
@@ -39,6 +49,14 @@ public class WorldStateDTO {
 
     public void setTrafficLightSystem(TrafficLightSystemDTO trafficLightSystem) {
         this.trafficLightSystem = trafficLightSystem;
+    }
+
+    public float getClock() {
+        return clock;
+    }
+
+    public void setClock(float clock){
+        this.clock = clock;
     }
 
 

--- a/src/main/java/thewaypointers/trafficsimulator/common/WorldStateDTO.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/WorldStateDTO.java
@@ -1,7 +1,7 @@
 package thewaypointers.trafficsimulator.common;
 
 public class WorldStateDTO {
-    private float clock;
+    private long clock;
     private MapDTO roadMap;
     private VehicleListDTO vehicleList;
     private TrafficLightSystemDTO trafficLightSystem;
@@ -22,7 +22,7 @@ public class WorldStateDTO {
     public WorldStateDTO(MapDTO roadMap,
                          VehicleListDTO vehicles,
                          TrafficLightSystemDTO trafficLightSystem,
-                         float clock){
+                         long clock){
         this(roadMap, vehicles, trafficLightSystem);
         this.clock = clock;
     }
@@ -51,11 +51,11 @@ public class WorldStateDTO {
         this.trafficLightSystem = trafficLightSystem;
     }
 
-    public float getClock() {
+    public long getClock() {
         return clock;
     }
 
-    public void setClock(float clock){
+    public void setClock(long clock){
         this.clock = clock;
     }
 

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/FirstVersionProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/FirstVersionProvider.java
@@ -42,6 +42,7 @@ public class FirstVersionProvider implements IStateProvider {
             throw new IllegalArgumentException("Cannot pass vehicleMovement bigger than the length of the road");
 
         stateNo++;
+        worldState.setClock(worldState.getClock()+vehicleMovement);
 
         RoadLocationDTO newLocation;
         if (loc.getDistanceTravelled() + vehicleMovement < loc.getRoad().getLength()) {

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/FirstVersionProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/FirstVersionProvider.java
@@ -42,7 +42,7 @@ public class FirstVersionProvider implements IStateProvider {
             throw new IllegalArgumentException("Cannot pass vehicleMovement bigger than the length of the road");
 
         stateNo++;
-        worldState.setClock(worldState.getClock()+vehicleMovement);
+        worldState.setClock(worldState.getClock()+(long)vehicleMovement);
 
         RoadLocationDTO newLocation;
         if (loc.getDistanceTravelled() + vehicleMovement < loc.getRoad().getLength()) {

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/JunctionTestProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/JunctionTestProvider.java
@@ -61,6 +61,7 @@ public class JunctionTestProvider implements IStateProvider {
 
             worldState.getVehicleList().setVehicleLocation(v.getLabel(), loc);
         }
+        worldState.setClock(worldState.getClock()+1);
         return worldState;
     }
 }

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/RoadNetworkProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/RoadNetworkProvider.java
@@ -62,7 +62,7 @@ public class RoadNetworkProvider implements IStateProvider {
             throw new IllegalArgumentException("Cannot pass vehicleMovement bigger than the length of the road");
 
         stateNo++;
-        worldState.setClock(worldState.getClock()+vehicleMovement);
+        worldState.setClock(worldState.getClock()+(long)vehicleMovement);
 
         RoadLocationDTO newLocation;
         if (loc.getDistanceTravelled() + vehicleMovement < loc.getRoad().getLength()) {

--- a/src/main/java/thewaypointers/trafficsimulator/common/helpers/RoadNetworkProvider.java
+++ b/src/main/java/thewaypointers/trafficsimulator/common/helpers/RoadNetworkProvider.java
@@ -62,6 +62,7 @@ public class RoadNetworkProvider implements IStateProvider {
             throw new IllegalArgumentException("Cannot pass vehicleMovement bigger than the length of the road");
 
         stateNo++;
+        worldState.setClock(worldState.getClock()+vehicleMovement);
 
         RoadLocationDTO newLocation;
         if (loc.getDistanceTravelled() + vehicleMovement < loc.getRoad().getLength()) {

--- a/src/main/java/thewaypointers/trafficsimulator/simulation/Simulation.java
+++ b/src/main/java/thewaypointers/trafficsimulator/simulation/Simulation.java
@@ -64,6 +64,7 @@ public class Simulation implements ISimulationInputListener {
             computeNextSimulationStep(RESOLUTION);
         }
         computeNextSimulationStep(timeLeft);
+        getWorldState().setClock(clock);
         return getWorldState();
     }
 

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionProviderTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionProviderTest.java
@@ -142,8 +142,8 @@ public class FirstVersionProviderTest {
         // act and assert
         WorldStateDTO result;
         result = provider.getNextState(moveDistance);
-        assertThat(result.getClock()).isEqualTo(moveDistance);
+        assertThat(result.getClock()).isEqualTo((long)moveDistance);
         result = provider.getNextState(moveDistance);
-        assertThat(result.getClock()).isEqualTo(moveDistance*2);
+        assertThat(result.getClock()).isEqualTo(((long)moveDistance)*2);
     }
 }

--- a/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionProviderTest.java
+++ b/src/test/java/thewaypointers/trafficsimulator/tests/common/helpers/FirstVersionProviderTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import thewaypointers.trafficsimulator.common.*;
 import thewaypointers.trafficsimulator.common.helpers.FirstVersionProvider;
 
-public class FirstVersionWorldStateProviderTest {
+public class FirstVersionProviderTest {
     @Test
     public void Provider_generates_correct_world_state() {
         // arrange
@@ -131,5 +131,19 @@ public class FirstVersionWorldStateProviderTest {
         assertThat(upColor).isEqualTo(downColor);
         assertThat(upColor).isNotEqualTo(upStartColor);
         assertThat(downColor).isNotEqualTo(downStartColor);
+    }
+
+    @Test
+    public void Provider_increments_simulation_time(){
+        // arrange
+        FirstVersionProvider provider = new FirstVersionProvider();
+        final float moveDistance = FirstVersionProvider.ROAD_LENGTH/6;
+
+        // act and assert
+        WorldStateDTO result;
+        result = provider.getNextState(moveDistance);
+        assertThat(result.getClock()).isEqualTo(moveDistance);
+        result = provider.getNextState(moveDistance);
+        assertThat(result.getClock()).isEqualTo(moveDistance*2);
     }
 }


### PR DESCRIPTION
Closes #51 .

Comments:
All world state providers and the simulation itself increment the clock in WorldStateDTO. It represents time in miliseconds.